### PR TITLE
Xmpp ping fixed to use the obtained jid.

### DIFF
--- a/xmpp.go
+++ b/xmpp.go
@@ -64,6 +64,10 @@ type Client struct {
 	p      *xml.Decoder
 }
 
+func (c *Client) JID() string {
+	return c.jid
+}
+
 func connect(host, user, passwd string) (net.Conn, error) {
 	addr := host
 

--- a/xmpp_ping.go
+++ b/xmpp_ping.go
@@ -5,6 +5,12 @@ import (
 )
 
 func (c *Client) PingC2S(jid, server string) error {
+	if jid == "" {
+		jid = c.jid
+	}
+	if server == "" {
+		server = c.domain
+	}
 	_, err := fmt.Fprintf(c.conn, "<iq from='%s' to='%s' id='c2s1' type='get'>\n"+
 		"<ping xmlns='urn:xmpp:ping'/>\n"+
 		"</iq>",


### PR DESCRIPTION
Though a client function, ping does not use the client jid.
Fixed ping to use the obtained jid and configured server domain by default.
Client now exposes its jid.